### PR TITLE
Temporary Tutorial Fix

### DIFF
--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -480,7 +480,7 @@ If you do not have this set up, run the following two commands:
 Now, restart the SEMPRE shell, pointing the SparqlExecutor to the Virtuoso
 instance:
 
-    ./sempre @mode=interact  @domain=webquestions  @sparqlserver=localhost:3093  @cacheserver=local  @load=15 @executeTopOnly=0 -Grammar.inPaths empty_grammar
+    ./sempre @mode=interact  @domain=webquestions  @sparqlserver=localhost:3093  @cacheserver=local  @load=15 @executeTopOnly=0 -Grammar.inPaths data/empty.grammar
 
 Now, we can add rules with semantic function `LexiconFn`:
 

--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -390,7 +390,7 @@ We can count the number of cities (should return 3):
 
 We can also get the city with the largest area:
 
-    (execute (argmax 1 1 (fb:type.object.type fb:location.citytown) !fb:location.location.area))
+    (execute (argmax 1 1 (fb:type.object.type fb:location.citytown) fb:location.location.area))
 
 Now let us take a closer look at what is going on with these logical forms
 under the hood.  We are using a logical language called lambda-DCS.

--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -480,7 +480,7 @@ If you do not have this set up, run the following two commands:
 Now, restart the SEMPRE shell, pointing the SparqlExecutor to the Virtuoso
 instance:
 
-    java -cp classes:lib/* edu.stanford.nlp.sempre.Main -executor SparqlExecutor -endpointUrl http://localhost:3093/sparql -interactive
+    ./sempre @mode=interact  @domain=webquestions  @sparqlserver=localhost:3093  @cacheserver=local  @load=15 @executeTopOnly=0 -Grammar.inPaths empty_grammar
 
 Now, we can add rules with semantic function `LexiconFn`:
 

--- a/src/edu/stanford/nlp/sempre/SparqlExecutor.java
+++ b/src/edu/stanford/nlp/sempre/SparqlExecutor.java
@@ -492,8 +492,7 @@ public class SparqlExecutor extends Executor {
         // Superlative (new environment, close scope)
         SuperlativeFormula formula = (SuperlativeFormula)rawFormula;
 
-        // boolean useOrderBy = formula.rank != 1 || formula.count != 1;
-        boolean useOrderBy = true; // Setting this flag to always be true to avoid the buggy argmax 1 1 case.
+        boolean useOrderBy = formula.rank != 1 || formula.count != 1;
         boolean isMax = formula.mode == SuperlativeFormula.Mode.argmax;
         if (useOrderBy) {
           // Method 1: use ORDER BY (can deal with offset and limit, but can't be nested, and doesn't handle ties at the top)
@@ -515,9 +514,6 @@ public class SparqlExecutor extends Executor {
           select.offset = formula.rank - 1;
           select.limit = formula.count;
           block.add(select);
-
-        // TODO: Fix this else case. I haven't understood the code yet, but all I know right is that this part,
-        // instead of resolving ties, seemingly answers with random entities
         } else {
           // Method 2: use MAX (can be nested, handles ties at the top)
           // (argmax 1 1 h r) ==> (h (r (mark degree (max ((reverse r) e)))))

--- a/src/edu/stanford/nlp/sempre/SparqlExecutor.java
+++ b/src/edu/stanford/nlp/sempre/SparqlExecutor.java
@@ -509,7 +509,8 @@ public class SparqlExecutor extends Executor {
           select.limit = formula.count;
           block.add(select);
 
-        // TODO: Fix this else case
+        // TODO: Fix this else case. I haven't understood the code yet, but all I know right is that this part,
+        // instead of resolving ties, seemingly answers with random entities
         } else {
           // Method 2: use MAX (can be nested, handles ties at the top)
           // (argmax 1 1 h r) ==> (h (r (mark degree (max ((reverse r) e)))))

--- a/src/edu/stanford/nlp/sempre/SparqlExecutor.java
+++ b/src/edu/stanford/nlp/sempre/SparqlExecutor.java
@@ -485,7 +485,8 @@ public class SparqlExecutor extends Executor {
         // Superlative (new environment, close scope)
         SuperlativeFormula formula = (SuperlativeFormula)rawFormula;
 
-        boolean useOrderBy = formula.rank != 1 || formula.count != 1;
+        // boolean useOrderBy = formula.rank != 1 || formula.count != 1;
+        boolean useOrderBy = true; // Setting this flag to always be true to avoid the buggy argmax 1 1 case.
         boolean isMax = formula.mode == SuperlativeFormula.Mode.argmax;
         if (useOrderBy) {
           // Method 1: use ORDER BY (can deal with offset and limit, but can't be nested, and doesn't handle ties at the top)
@@ -507,6 +508,8 @@ public class SparqlExecutor extends Executor {
           select.offset = formula.rank - 1;
           select.limit = formula.count;
           block.add(select);
+
+        // TODO: Fix this else case
         } else {
           // Method 2: use MAX (can be nested, handles ties at the top)
           // (argmax 1 1 h r) ==> (h (r (mark degree (max ((reverse r) e)))))


### PR DESCRIPTION
Currently, the last exercise that adds rules to parse "physicists born in Ulm" doesn't work, because the command

java -cp classes:lib/* edu.stanford.nlp.sempre.Main -executor SparqlExecutor -endpointUrl http://localhost:3093/sparql -interactive

is missing many flags that running ./sempre automatically sets. Until all the missing flags are identified/added, this temporary replacement instructs the user to call sempre using ./sempre instead (with an empty_grammar file to override the default emnlp grammar) so that the rules given in the Tutorial work properly.