### PR TITLE
[tables] Fixed date comparison in LambdaDCSExecutor

### DIFF
--- a/src/edu/stanford/nlp/sempre/tables/TableKnowledgeGraph.java
+++ b/src/edu/stanford/nlp/sempre/tables/TableKnowledgeGraph.java
@@ -608,13 +608,19 @@ public class TableKnowledgeGraph extends KnowledgeGraph implements FuzzyMatchabl
     return null;
   }
 
+  public Value getNameValueWithOriginalString(NameValue value) {
+    if (value.description == null)
+      value = new NameValue(value.id, getOriginalString(value.id));
+    return value;
+  }
+
   public ListValue getListValueWithOriginalStrings(ListValue answers) {
     List<Value> values = new ArrayList<>();
     for (Value value : answers.values) {
       if (value instanceof NameValue) {
         NameValue name = (NameValue) value;
         if (name.description == null)
-          value = new NameValue(name.id, getOriginalString(((NameValue) value).id));
+          value = new NameValue(name.id, getOriginalString(name.id));
       }
       values.add(value);
     }

--- a/src/edu/stanford/nlp/sempre/tables/TableValueEvaluator.java
+++ b/src/edu/stanford/nlp/sempre/tables/TableValueEvaluator.java
@@ -23,6 +23,8 @@ public class TableValueEvaluator implements ValueEvaluator {
     public boolean allowNormalizedStringMatch = true;
     @Option(gloss = "When comparing number values, only consider the value and not the unit")
     public boolean ignoreNumberValueUnits = true;
+    @Option(gloss = "Strict date evaluation (year, month, and date all have to match)")
+    public boolean strictDateEvaluation = false;
   }
   public static Options opts = new Options();
 
@@ -113,11 +115,15 @@ public class TableValueEvaluator implements ValueEvaluator {
   }
 
   protected boolean compareDateValues(DateValue target, DateValue pred) {
-    // If a field in target is not blank (-1), pred must match target on that field
-    if (target.year != -1 && target.year != pred.year) return false;
-    if (target.month != -1 && target.month != pred.month) return false;
-    if (target.day != -1 && target.day != pred.day) return false;
-    return true;
+    if (opts.strictDateEvaluation) {
+      return target.equals(pred);
+    } else {
+      // If a field in target is not blank (-1), pred must match target on that field
+      if (target.year != -1 && target.year != pred.year) return false;
+      if (target.month != -1 && target.month != pred.month) return false;
+      if (target.day != -1 && target.day != pred.day) return false;
+      return true;
+    }
   }
 
 }

--- a/src/edu/stanford/nlp/sempre/tables/lambdadcs/LambdaDCSExecutor.java
+++ b/src/edu/stanford/nlp/sempre/tables/lambdadcs/LambdaDCSExecutor.java
@@ -205,6 +205,8 @@ class LambdaDCSCoreLogic {
         // Rule out binaries
         if (CanonicalNames.isBinary(value) && LambdaDCSExecutor.opts.executeBinary)
           throw new LambdaDCSException(Type.notUnary, "[Unary] Binary value %s", formula);
+        if (value instanceof NameValue && graph instanceof TableKnowledgeGraph)
+          value = ((TableKnowledgeGraph) graph).getNameValueWithOriginalString((NameValue) value);
         // Other cases
         return typeHint.applyBound(new ExplicitUnaryDenotation(value));
       }

--- a/src/edu/stanford/nlp/sempre/tables/lambdadcs/LambdaDCSExecutorTest.java
+++ b/src/edu/stanford/nlp/sempre/tables/lambdadcs/LambdaDCSExecutorTest.java
@@ -152,6 +152,8 @@ public class LambdaDCSExecutorTest {
       return TableKnowledgeGraph.fromFilename("tables/toy-examples/random/nikos_machlas.csv");
     } else if ("csv2".equals(name)) {
       return TableKnowledgeGraph.fromFilename("lib/data/tables/csv/204-csv/495.tsv");
+    } else if ("csv3".equals(name)) {
+      return TableKnowledgeGraph.fromFilename("lib/data/tables/csv/203-csv/839.tsv");
     }
     throw new RuntimeException("Unknown graph name: " + name);
   }
@@ -247,14 +249,18 @@ public class LambdaDCSExecutorTest {
   
   @Test(groups = "lambdaCSV2") public void lambdaOnGraphCSV2Test() {
     KnowledgeGraph graph = getKnowledgeGraph("csv2");
-    // fb:cell.away', 'fb:row.row.venue', '!fb:row.row.result',
-    // '!fb:cell.cell.num2', 'avg', 'fb:row.row.index', 'fb:row.row.next', '!fb:row.row.opponent'
-    //runFormula(executor,
-    //    "(!fb:row.row.opponent (fb:row.row.next (fb:row.row.index (avg (!fb:cell.cell.num2 (!fb:row.row.result (fb:row.row.venue fb:cell.away)))))))",
-    //    graph, matches("(name fb:cell.derby_county)"));
     runFormula(executor,
         "(and (!= (and (!= fb:cell.away) fb:cell.home)) ((reverse fb:row.row.opponent) (fb:row.row.index (- (number 1) (number 1)))))",
         graph, matches("(name fb:cell.derby_county)"));
   }
-
+  
+  @Test(groups = "lambdaCSV3") public void lambdaOnGraphCSV3Test() {
+    KnowledgeGraph graph = getKnowledgeGraph("csv3");
+    runFormula(executor,
+        "(count (fb:type.object.type fb:type.row))",
+        graph, matches("(number 21)"));
+    runFormula(executor,
+        "(count (fb:row.row.opened (fb:cell.cell.date (< (date 1926 -1 -1)))))",
+        graph, matches("(number 6)"));
+  }
 }

--- a/src/edu/stanford/nlp/sempre/tables/lambdadcs/LambdaDCSExecutorTest.java
+++ b/src/edu/stanford/nlp/sempre/tables/lambdadcs/LambdaDCSExecutorTest.java
@@ -4,6 +4,7 @@ import java.util.*;
 
 import fig.basic.*;
 import edu.stanford.nlp.sempre.*;
+import edu.stanford.nlp.sempre.corenlp.CoreNLPAnalyzer;
 import edu.stanford.nlp.sempre.tables.TableKnowledgeGraph;
 
 import org.testng.annotations.Test;
@@ -253,14 +254,22 @@ public class LambdaDCSExecutorTest {
         "(and (!= (and (!= fb:cell.away) fb:cell.home)) ((reverse fb:row.row.opponent) (fb:row.row.index (- (number 1) (number 1)))))",
         graph, matches("(name fb:cell.derby_county)"));
   }
-  
+
   @Test(groups = "lambdaCSV3") public void lambdaOnGraphCSV3Test() {
+    LanguageAnalyzer.setSingleton(new CoreNLPAnalyzer());
     KnowledgeGraph graph = getKnowledgeGraph("csv3");
     runFormula(executor,
         "(count (fb:type.object.type fb:type.row))",
         graph, matches("(number 21)"));
     runFormula(executor,
         "(count (fb:row.row.opened (fb:cell.cell.date (< (date 1926 -1 -1)))))",
+        graph, matches("(number 6)"));
+    runFormula(executor,
+        "(sum (- (count ((reverse fb:row.row.index) (fb:type.object.type fb:type.row))) " +
+            "((reverse fb:row.row.index) (fb:row.row.latitude ((reverse fb:row.row.longitude) (fb:type.object.type fb:type.row))))))",
+        graph, matches("(number 6)"));
+    runFormula(executor,
+        "(- (number 1926) (argmax (number 1) (number 1) ((reverse fb:cell.cell.number) (or (or (or fb:cell.1920 fb:cell.1925) fb:cell.1926) fb:cell.1946)) (reverse (lambda x (sum ((reverse fb:cell.cell.number) (fb:cell.cell.number (var x))))))))",
         graph, matches("(number 6)"));
   }
 }

--- a/src/edu/stanford/nlp/sempre/tables/serialize/DumpFilterer.java
+++ b/src/edu/stanford/nlp/sempre/tables/serialize/DumpFilterer.java
@@ -1,0 +1,90 @@
+package edu.stanford.nlp.sempre.tables.serialize;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.PrintWriter;
+import java.util.*;
+
+import edu.stanford.nlp.sempre.*;
+import fig.basic.*;
+import fig.exec.Execution;
+
+public class DumpFilterer implements Runnable {
+  public static class Options {
+    @Option(gloss = "verbosity") public int verbose = 0;
+    @Option(gloss = "input dump directory")
+    public String filtererInputDumpDirectory;
+  }
+  public static Options opts = new Options();
+
+  public static void main(String[] args) {
+    Execution.run(args, "DumpFiltererMain", new DumpFilterer(), Master.getOptionsParser());
+  }
+  
+  Builder builder;
+
+  @Override
+  public void run() {
+    builder = new Builder();
+    builder.build();
+    String outDir = Execution.getFile("filtered");
+    new File(outDir).mkdirs();
+    for (Pair<String, String> pathPair : Dataset.opts.inPaths) {
+      String group = pathPair.getFirst();
+      String path = pathPair.getSecond();
+      // Read LispTrees
+      LogInfo.begin_track("Reading %s", path);
+      int maxExamples = Dataset.getMaxExamplesForGroup(group);
+      Iterator<LispTree> trees = LispTree.proto.parseFromFile(path);
+      // Go through the examples
+      int n = 0;
+      while (n < maxExamples) {
+        // Format: (example (id ...) (utterance ...) (targetFormula ...) (targetValue ...))
+        LispTree tree = trees.next();
+        if (tree == null) break;
+        if (tree.children.size() < 2 || !"example".equals(tree.child(0).value)) {
+          if ("metadata".equals(tree.child(0).value)) continue;
+          throw new RuntimeException("Invalid example: " + tree);
+        }
+        Example ex = Example.fromLispTree(tree, path + ":" + n);
+        ex.preprocess();
+        LogInfo.logs("Example %s (%d): %s => %s", ex.id, n, ex.getTokens(), ex.targetValue);
+        n++;
+        processExample(ex);
+      }
+      LogInfo.end_track();
+    }
+  }
+
+  private void processExample(Example ex) {
+    File inPath = new File(opts.filtererInputDumpDirectory, ex.id + ".gz");
+    File outPath = new File(Execution.getFile("filtered"), ex.id + ".gz");
+    try {
+      BufferedReader reader = IOUtils.openInHard(inPath);
+      PrintWriter writer = IOUtils.openOutHard(outPath);
+      int inLines = 0, outLines = 0;
+      String line;
+      while ((line = reader.readLine()) != null) {
+        inLines++;
+        LispTree tree = LispTree.proto.parseFromString(line);
+        if (!"formula".equals(tree.child(1).child(0).value))
+          throw new RuntimeException("Invalid tree: " + tree);
+        Formula formula = Formulas.fromLispTree(tree.child(1).child(1));
+        Value value = builder.executor.execute(formula, ex.context).value;
+        double compatibility = builder.valueEvaluator.getCompatibility(ex.targetValue, value);
+        if (compatibility == 1.0) {
+          writer.println(tree);
+          outLines++;
+        } else if (opts.verbose >= 2) {
+          LogInfo.logs("Filtered out %s <= %s", value, formula);
+        }
+      }
+      LogInfo.logs("Filtered %d => %d", inLines, outLines);
+      reader.close();
+      writer.close();
+    } catch (Exception e) {
+      LogInfo.warnings("Got an error: %s", e);
+    }
+  }
+
+}

--- a/tables/dump-parsers/convert-to-postfix.py
+++ b/tables/dump-parsers/convert-to-postfix.py
@@ -5,7 +5,7 @@
 If the file is tab-separated, only process the first column.
 """
 
-import sys, os, shutil, re, argparse, json
+import sys, os, shutil, re, argparse, json, gzip
 from codecs import open
 from itertools import izip
 from collections import defaultdict


### PR DESCRIPTION
* Only allow min, max, argmin, argmax if all dates are comparable.
    For example, do not allow max on {(date 2010 -1 -1), (date -1 4 5)} since the dates are not comparable. Tests are added accordingly.
* Added an option to allow more strict date evaluation: if the target answer is "January", do not allow (date 1990 1 4). Also added a dump filter to filter the dumped consistent logical forms based on this new evaluation.