### PR TITLE
[tables] In CoreNLP-tagged table dumpers, renamed "annotated" to "tagged" to avoid confusion 

### DIFF
--- a/pull-dependencies
+++ b/pull-dependencies
@@ -150,7 +150,11 @@ addModule('corenlp', 'Stanford CoreNLP 3.6.0', lambda {
    'stanford-corenlp-3.6.0-models.jar' => 'stanford-corenlp-models.jar',
    'stanford-corenlp-caseless-2015-04-20-models.jar' => 'stanford-corenlp-caseless-models.jar',
    'joda-time.jar' => 'joda-time.jar',
-   'jollyday.jar' => 'jollyday.jar'}.each { |key, value|
+   'jollyday.jar' => 'jollyday.jar',
+   'ejml-0.23.jar' => 'ejml.jar',
+   'slf4j-api.jar' => 'slf4j-api.jar',
+   'slf4j-simple.jar' => 'slf4j-simple.jar',
+  }.each { |key, value|
     system "ln -sfv stanford-corenlp-full-2015-12-09/#{key} lib/#{value}" or exit 1
   }
 })
@@ -170,7 +174,8 @@ addModule('corenlp-3.2.0', 'Stanford CoreNLP 3.2.0 (for backward reproducibility
    'stanford-corenlp-3.2.0-models.jar' => 'stanford-corenlp-models.jar',
    'stanford-corenlp-caseless-2013-06-07-models.jar' => 'stanford-corenlp-caseless-models.jar',
    'joda-time.jar' => 'joda-time.jar',
-   'jollyday.jar' => 'jollyday.jar'}.each { |key, value|
+   'jollyday.jar' => 'jollyday.jar'
+  }.each { |key, value|
     system "ln -sfv stanford-corenlp-full-2013-06-20/#{key} lib/#{value}" or exit 1
   }
 })
@@ -275,6 +280,10 @@ if ARGV.size == 0
   $modules.each { |name,description,func|
     puts "  #{name}: #{description}"
   }
+  puts
+  puts "Internal use (Stanford NLP only):"
+  puts "  #{$0} -l <module-1> ...: Get the files from the local Stanford NLP server instead"
+  puts "  #{$0} -l -r <module-1> ...: Release to the public www directory on the server"
 end
 
 $modules.each { |name,description,func|

--- a/run
+++ b/run
@@ -623,10 +623,11 @@ addMode('tables', 'QA on HTML tables', lambda { |e| l(
     'dump' => 'edu.stanford.nlp.sempre.tables.serialize.SerializedDumper',
     'load' => l('edu.stanford.nlp.sempre.tables.serialize.SerializedLoader', let(:parser, 'serialized')),
     'stats' => 'edu.stanford.nlp.sempre.tables.test.TableStatsComputer',
-    'ann-data' => 'edu.stanford.nlp.sempre.tables.serialize.AnnotatedDatasetGenerator',
-    'ann-table' => 'edu.stanford.nlp.sempre.tables.serialize.AnnotatedTableGenerator',
+    'tag-data' => 'edu.stanford.nlp.sempre.tables.serialize.TaggedDatasetGenerator',
+    'tag-table' => 'edu.stanford.nlp.sempre.tables.serialize.TaggedTableGenerator',
     'alter' => l('edu.stanford.nlp.sempre.tables.alter.BatchTableAlterer', let(:parser, 'serialized')),
     'alter-ex' => l('edu.stanford.nlp.sempre.tables.alter.AlteredTablesExecutor', let(:parser, 'serialized')),
+    'filter' => 'edu.stanford.nlp.sempre.tables.serialize.DumpFilterer',
   }),
   # Fig parameters
   selo(:cldir, 'execDir', '_OUTPATH_', 'output'),
@@ -649,7 +650,7 @@ addMode('tables', 'QA on HTML tables', lambda { |e| l(
     nil),
   }),
   # Parser
-  letDefault(:parser, 'floatsize'),
+  letDefault(:parser, 'old-floatsize'),
   sel(:parser, {
     'old-floatsize' => l(
       o('Builder.parser', 'FloatingParser'),
@@ -860,13 +861,11 @@ def tablesDataPaths
     csvDir = ['lib/data/tables/', 'WikiTableQuestions/'][e[:cldir]]
     datasets = {
       'none' => l(),
+      'train' => o('Dataset.inPaths', "train,#{baseDir}training.examples"),
       # Pristine test test
-      'test' => l(
-        o('Dataset.inPaths',
-          "train,#{baseDir}training.examples",
-          "test,#{baseDir}pristine-unseen-tables.examples"),
-        o('Dataset.trainFrac', 1), o('Dataset.devFrac', 0),
-      nil),
+      'test' => o('Dataset.inPaths',
+        "train,#{baseDir}training.examples",
+        "test,#{baseDir}pristine-unseen-tables.examples"),
       # @data=annotated can be used with @class=check only
       'annotated' => o('Dataset.inPaths', "train,#{baseDir}annotated-all.examples"),
       'before300' => o('Dataset.inPaths', "train,#{baseDir}training-before300.examples"),

--- a/src/edu/stanford/nlp/sempre/tables/serialize/TSVGenerator.java
+++ b/src/edu/stanford/nlp/sempre/tables/serialize/TSVGenerator.java
@@ -5,7 +5,12 @@ import java.util.*;
 
 import edu.stanford.nlp.sempre.*;
 
-public class AnnotatedGenerator {
+/**
+ * Generate a TSV file for the dataset release.
+ * 
+ * @author ppasupat
+ */
+public class TSVGenerator {
   protected PrintWriter out;
 
   protected void dump(String... stuff) {

--- a/src/edu/stanford/nlp/sempre/tables/serialize/TaggedTableGenerator.java
+++ b/src/edu/stanford/nlp/sempre/tables/serialize/TaggedTableGenerator.java
@@ -14,7 +14,7 @@ import fig.basic.LogInfo;
 import fig.exec.Execution;
 
 /**
- * Generate TSV files containing CoreNLP annotation of the tables.
+ * Generate TSV files containing CoreNLP tags of the tables.
  *
  * Mandatory fields:
  * - row:         row index (-1 is the header row)
@@ -40,10 +40,10 @@ import fig.exec.Execution;
  *
  * @author ppasupat
  */
-public class AnnotatedTableGenerator extends AnnotatedGenerator implements Runnable {
+public class TaggedTableGenerator extends TSVGenerator implements Runnable {
 
   public static void main(String[] args) {
-    Execution.run(args, "AnnotatedTableGeneratorMain", new AnnotatedTableGenerator(),
+    Execution.run(args, "TaggedTableGeneratorMain", new TaggedTableGenerator(),
         Master.getOptionsParser());
   }
 
@@ -65,8 +65,8 @@ public class AnnotatedTableGenerator extends AnnotatedGenerator implements Runna
             int batchIndex = Integer.parseInt(matcher.group(1)),
                 dataIndex = Integer.parseInt(matcher.group(2));
             TableKnowledgeGraph table = TableKnowledgeGraph.fromFilename(baseDir.relativize(file).toString());
-            String outDir = Execution.getFile("annotated/" + batchIndex + "-annotated/"),
-                outFilename = new File(outDir, dataIndex + ".annotated").getPath();
+            String outDir = Execution.getFile("tagged/" + batchIndex + "-tagged/"),
+                outFilename = new File(outDir, dataIndex + ".tagged").getPath();
             new File(outDir).mkdirs();
             out = IOUtils.openOutHard(outFilename);
             dumpTable(table);


### PR DESCRIPTION
In the utilities for dumping CoreNLP-tagged tables and datasets, renamed "annotated" to "tagged" to avoid confusion with "annotated with gold logical forms".