### PR TITLE
New primitive SemanticFn: Filter

### DIFF
--- a/src/edu/stanford/nlp/sempre/FilterFormula.java
+++ b/src/edu/stanford/nlp/sempre/FilterFormula.java
@@ -1,0 +1,64 @@
+package edu.stanford.nlp.sempre;
+
+import com.google.common.base.Function;
+import fig.basic.LispTree;
+
+import java.util.List;
+
+/**
+ * (filter x y): Find the set of all elements in x that function y evaluates to a non-empty set.   
+ *
+ * @author Panupong Pasupat
+ */
+public class FilterFormula extends Formula {
+  public enum Mode { argmin, argmax };
+
+  public final Formula domain;
+  public final Formula condition;
+
+  public FilterFormula(Formula domain, Formula condition) {
+    this.domain = domain;
+    this.condition = condition;
+  }
+
+  public LispTree toLispTree() {
+    LispTree tree = LispTree.proto.newList();
+    tree.addChild("filter");
+    tree.addChild(domain.toLispTree());
+    tree.addChild(condition.toLispTree());
+    return tree;
+  }
+
+  public Formula map(Function<Formula, Formula> func) {
+    Formula result = func.apply(this);
+    return result == null ? new FilterFormula(domain.map(func), condition.map(func)) : result;
+  }
+
+  @Override
+  public List<Formula> mapToList(Function<Formula, List<Formula>> func, boolean alwaysRecurse) {
+    List<Formula> res = func.apply(this);
+    if (res.isEmpty() || alwaysRecurse) {
+      res.addAll(domain.mapToList(func, alwaysRecurse));
+      res.addAll(condition.mapToList(func, alwaysRecurse));
+    }
+    return res;
+  }
+
+  @SuppressWarnings({"equalshashcode"})
+  @Override
+  public boolean equals(Object thatObj) {
+    if (!(thatObj instanceof FilterFormula)) return false;
+    FilterFormula that = (FilterFormula) thatObj;
+    if (!this.domain.equals(that.domain)) return false;
+    if (!this.condition.equals(that.condition)) return false;
+    return true;
+  }
+
+  public int computeHashCode() {
+    int hash = 0x7ed55d16;
+    hash = hash * 0xd3a2646c + domain.hashCode();
+    hash = hash * 0xd3a2646c + condition.hashCode();
+    return hash;
+  }
+}
+

--- a/src/edu/stanford/nlp/sempre/Formulas.java
+++ b/src/edu/stanford/nlp/sempre/Formulas.java
@@ -41,6 +41,8 @@ public abstract class Formulas {
           args.add(fromLispTree(tree.child(i)));
         return new CallFormula(callFunc, args);
       }
+      if (func.equals("filter"))
+        return new FilterFormula(fromLispTree(tree.child(1)), fromLispTree(tree.child(2)));
     }
 
     { // Merge: (and (fb:type.object.type fb:people.person) (fb:people.person.children fb:en.barack_obama))
@@ -183,6 +185,10 @@ public abstract class Formulas {
     if (formula instanceof NotFormula) {
       NotFormula notForm = (NotFormula) formula;
       return containsFreeVar(notForm.child, var);
+    }
+    if (formula instanceof FilterFormula) {
+      FilterFormula filter = (FilterFormula) formula;
+      return containsFreeVar(filter.domain, var) || containsFreeVar(filter.condition, var);
     }
     throw new RuntimeException("Unhandled: " + formula);
   }

--- a/src/edu/stanford/nlp/sempre/TypeInference.java
+++ b/src/edu/stanford/nlp/sempre/TypeInference.java
@@ -247,6 +247,14 @@ public final class TypeInference {
       for (int i = 0; i < info.argTypes.size(); i++)
         inferType(call.args.get(i), env, info.argTypes.get(i));
       return check(type.meet(info.retType));
+      
+    } else if (formula instanceof FilterFormula) {
+      FilterFormula filter = (FilterFormula) formula;
+      type = check(type.meet(SemType.anyType));  // Must be not higher-order
+      type = inferType(filter.domain, env, type); // Domain
+      inferType(filter.condition, env, SemType.anyAnyFunc);
+      return type;
+      
     } else {
       throw new RuntimeException("Can't infer type of formula: " + formula);
     }

--- a/src/edu/stanford/nlp/sempre/tables/lambdadcs/ExplicitBinaryDenotation.java
+++ b/src/edu/stanford/nlp/sempre/tables/lambdadcs/ExplicitBinaryDenotation.java
@@ -98,4 +98,19 @@ public class ExplicitBinaryDenotation extends BinaryDenotation {
     return new ExplicitBinaryDenotation(filtered);
   }
 
+  public UnaryDenotation getFirsts() {
+    Set<Value> firsts = new HashSet<>();
+    for (Pair<Value, Value> pair : pairs) {
+      firsts.add(pair.getFirst());
+    }
+    return new ExplicitUnaryDenotation(firsts);
+  }
+  
+  public UnaryDenotation getSeconds() {
+    Set<Value> seconds = new HashSet<>();
+    for (Pair<Value, Value> pair : pairs) {
+      seconds.add(pair.getSecond());
+    }
+    return new ExplicitUnaryDenotation(seconds);
+  }
 }

--- a/src/edu/stanford/nlp/sempre/tables/lambdadcs/LambdaDCSExecutor.java
+++ b/src/edu/stanford/nlp/sempre/tables/lambdadcs/LambdaDCSExecutor.java
@@ -251,7 +251,6 @@ class LambdaDCSCoreLogic {
       UnaryDenotation domainD = computeUnary(filter.domain, typeHint);
       BinaryDenotation conditionD = computeBinary(filter.condition, typeHint.newRestrictedBinary(null, domainD));
       ExplicitBinaryDenotation table = conditionD.explicitlyFilterSecond(domainD, graph);
-      LogInfo.logs("%s %s", typeHint, table.getSeconds());
       return typeHint.applyBound(table.getSeconds());
       
     } else {

--- a/src/edu/stanford/nlp/sempre/tables/lambdadcs/LambdaDCSExecutor.java
+++ b/src/edu/stanford/nlp/sempre/tables/lambdadcs/LambdaDCSExecutor.java
@@ -190,12 +190,6 @@ class LambdaDCSCoreLogic {
         }
       }
 
-    } else if (formula instanceof NotFormula) {
-      // ============================================================
-      // Not
-      // ============================================================
-      // TODO(ice): (Low priority)
-
     } else if (formula instanceof AggregateFormula) {
       // ============================================================
       // Aggregate
@@ -225,12 +219,6 @@ class LambdaDCSCoreLogic {
       UnaryDenotation child2D = computeUnary(arithmetic.child2, typeHint.newUnrestrictedUnary());
       return typeHint.applyBound(DenotationUtils.arithmetic(child1D, child2D, arithmetic.mode));
 
-    } else if (formula instanceof CallFormula) {
-      // ============================================================
-      // Call
-      // ============================================================
-      // TODO(ice): (Low priority)
-
     } else if (formula instanceof VariableFormula) {
       // ============================================================
       // Variable
@@ -255,6 +243,17 @@ class LambdaDCSCoreLogic {
       }
       return typeHint.applyBound(new ExplicitUnaryDenotation(values));
 
+    } else if (formula instanceof FilterFormula) {
+      // ============================================================
+      // Filter
+      // ============================================================
+      FilterFormula filter = (FilterFormula) formula;
+      UnaryDenotation domainD = computeUnary(filter.domain, typeHint);
+      BinaryDenotation conditionD = computeBinary(filter.condition, typeHint.newRestrictedBinary(null, domainD));
+      ExplicitBinaryDenotation table = conditionD.explicitlyFilterSecond(domainD, graph);
+      LogInfo.logs("%s %s", typeHint, table.getSeconds());
+      return typeHint.applyBound(table.getSeconds());
+      
     } else {
       throw new LambdaDCSException(Type.notUnary, "[Unary] Not a unary " + formula);
     }

--- a/src/edu/stanford/nlp/sempre/tables/test/CustomExample.java
+++ b/src/edu/stanford/nlp/sempre/tables/test/CustomExample.java
@@ -114,8 +114,8 @@ public class CustomExample extends Example {
     formulaMacros.put("@!p.second", "!" + TableTypeSystem.CELL_SECOND_VALUE.id);
   }
 
-  static final Pattern regexProperty = Pattern.compile("c\\.(.*)");
-  static final Pattern regexReversedProperty = Pattern.compile("!c\\.(.*)");
+  static final Pattern regexProperty = Pattern.compile("r\\.(.*)");
+  static final Pattern regexReversedProperty = Pattern.compile("!r\\.(.*)");
   static final Pattern regexEntity = Pattern.compile("c_(.*)\\.(.*)");
 
   /**

--- a/src/edu/stanford/nlp/sempre/tables/test/DPParserChecker.java
+++ b/src/edu/stanford/nlp/sempre/tables/test/DPParserChecker.java
@@ -184,6 +184,10 @@ public class DPParserChecker implements Runnable {
       } else if (formula instanceof LambdaFormula) {
         LambdaFormula lambda = (LambdaFormula) formula;
         return new LambdaFormula("x", canonicalizeFormula(lambda.body));
+      } else if (formula instanceof FilterFormula) {
+        FilterFormula filter = (FilterFormula) formula;
+        return new FilterFormula(
+            canonicalizeFormula(filter.domain), canonicalizeFormula(filter.condition));
       } else {
         throw new RuntimeException("Unsupported formula " + formula);
       }

--- a/tables/grammars/combined.grammar
+++ b/tables/grammars/combined.grammar
@@ -296,6 +296,25 @@
 )
 
 ################################
+# EXPERIMENTAL: Filter
+
+# [TAG] filter: "players with more wins than losses"
+(when filter
+  # Equal: Find rows r where f1(r) = f2(r)
+  # "Players with equal wins as losses"
+  (rule $RowSet ($RowSet $FnOnRow $FnOnRow)
+    (lambda r (lambda f1 (lambda f2 (filter (var r) (lambda x (and ((var f1) (var x)) ((var f2) (var x))))))))
+  )
+  # Compare: Similar to above but with different comparators
+  # "Players with more wins than losses"
+  (for @comparison (< > <= >=)
+    (rule $RowSet ($RowSet $FnOnRow $FnOnRow)
+      (lambda r (lambda f1 (lambda f2 (filter (var r) (lambda x (and ((var f1) (var x)) (@comparison ((var f2) (var x)))))))))
+    )
+  )
+)
+
+################################
 # ROOT
 (rule $ROOT ($ValueSet) (IdentityFn))
 (rule $ROOT ($SingleValue) (IdentityFn))


### PR DESCRIPTION
"Find all cities with more teachers than farmers"

This is a highly requested semantic function. One way to answer the question above in the original set of semantic function is
```
(mark x (and (type city) (: (and (!num_teachers (var x)) (> (!num_farmers (var x)))))))
```
where the special relation `:` returns an empty set when the argument is empty, and `*` otherwise. The relation `:` has not been implemented.

The proposed semantic function looks like this:
```
(filter (type city) (lambda x (and (!num_teachers (var x)) (> (!num_farmers (var x))))))
```
While it is equally long, I think it is a little clearer about what it does. `(filter S F)` is equivalent to `{x in S : F(x) not empty}`. Filter is also easier to execute than the generic mark since filter is similar to superlatives (i.e., try plugging each value in `S` into the function `F` and see what works).

Please refer to `tables/grammars/combined.grammar ` of how it could be used in the grammar.