### PR TITLE
Add more string args to JavaExecutor plus function

### DIFF
--- a/src/edu/stanford/nlp/sempre/JavaExecutor.java
+++ b/src/edu/stanford/nlp/sempre/JavaExecutor.java
@@ -110,6 +110,18 @@ public class JavaExecutor extends Executor {
     public static String plus(String a, String b, String c, String d, String e, String f, String g, String h, String i, String j, String k) {
       return a + b + c + d + e + f + g + h + i + j + k;
     }
+    public static String plus(String a, String b, String c, String d, String e, String f, String g, String h, String i, String j, String k, String l) {
+      return a + b + c + d + e + f + g + h + i + j + k + l;
+    }
+    public static String plus(String a, String b, String c, String d, String e, String f, String g, String h, String i, String j, String k, String l, String m) {
+      return a + b + c + d + e + f + g + h + i + j + k + l + m;
+    }
+    public static String plus(String a, String b, String c, String d, String e, String f, String g, String h, String i, String j, String k, String l, String m, String n) {
+      return a + b + c + d + e + f + g + h + i + j + k + l + m + n;
+    }
+    public static String plus(String a, String b, String c, String d, String e, String f, String g, String h, String i, String j, String k, String l, String m, String n, String o) {
+      return a + b + c + d + e + f + g + h + i + j + k + l + m + n + o;
+    }
     private static String toString(Object x) {
       if (x instanceof String)
         return (String) x;

--- a/src/edu/stanford/nlp/sempre/JavaExecutor.java
+++ b/src/edu/stanford/nlp/sempre/JavaExecutor.java
@@ -98,6 +98,18 @@ public class JavaExecutor extends Executor {
     public static String plus(String a, String b, String c, String d, String e, String f, String g) {
       return a + b + c + d + e + f + g;
     }
+    public static String plus(String a, String b, String c, String d, String e, String f, String g, String h) {
+      return a + b + c + d + e + f + g + h;
+    }
+    public static String plus(String a, String b, String c, String d, String e, String f, String g, String h, String i) {
+      return a + b + c + d + e + f + g + h + i;
+    }
+    public static String plus(String a, String b, String c, String d, String e, String f, String g, String h, String i, String j) {
+      return a + b + c + d + e + f + g + h + i + j;
+    }
+    public static String plus(String a, String b, String c, String d, String e, String f, String g, String h, String i, String j, String k) {
+      return a + b + c + d + e + f + g + h + i + j + k;
+    }
     private static String toString(Object x) {
       if (x instanceof String)
         return (String) x;


### PR DESCRIPTION
when 7 string args just ain't enough ..

I have a use case where SEMPRE output involves concatenating a lot of strings, needed to add to the plus rules so that would not get BADJAVA error when derivations contain more than 7 string arguments

added up to 15 arguments