### PR TITLE
Added corenlp-3.9.2 + disable SUTime

### DIFF
--- a/pull-dependencies
+++ b/pull-dependencies
@@ -187,6 +187,31 @@ addModule('corenlp-3.2.0', 'Stanford CoreNLP 3.2.0 (for backward reproducibility
   }
 })
 
+addModule('corenlp-3.9.2', 'Stanford CoreNLP 3.9.2 (if the default one does not run on newer Java)', lambda {
+  pull('http://nlp.stanford.edu/software/stanford-corenlp-full-2018-10-05.zip', '')
+  if not File.exists?('lib/stanford-corenlp-full-2018-10-05')
+    system "cd lib && unzip stanford-corenlp-full-2018-10-05.zip" or exit 1
+  end
+  pull('http://nlp.stanford.edu/software/stanford-english-corenlp-2018-10-05-models.jar',
+       'stanford-corenlp-full-2018-10-05', {:symlink => true})
+  pull('http://central.maven.org/maven2/javax/xml/bind/jaxb-api/2.3.0/jaxb-api-2.3.0.jar', '')
+  # Remove old file (for backward compatibility)
+  if Dir.glob('lib/stanford-corenlp*.jar').any?
+    system 'rm -v lib/stanford-corenlp*.jar' or exit 1
+  end
+  {'stanford-corenlp-3.9.2.jar' => 'stanford-corenlp.jar',
+   'stanford-corenlp-3.9.2-models.jar' => 'stanford-corenlp-models.jar',
+   'stanford-english-corenlp-2018-10-05-models.jar' => 'stanford-corenlp-caseless-models.jar',
+   'joda-time.jar' => 'joda-time.jar',
+   'jollyday.jar' => 'jollyday.jar',
+   'ejml-0.23.jar' => 'ejml.jar',
+   'slf4j-api.jar' => 'slf4j-api.jar',
+   'slf4j-simple.jar' => 'slf4j-simple.jar',
+  }.each { |key, value|
+    system "ln -sfv stanford-corenlp-full-2018-10-05/#{key} lib/#{value}" or exit 1
+  }
+})
+
 addModule('freebase', 'Freebase: need to construct Freebase schemas', lambda {
   # Freebase schema
   pull('/u/nlp/data/semparse/scr/freebase/state/execs/93.exec/schema2.ttl', 'fb_data/93.exec')

--- a/run
+++ b/run
@@ -523,7 +523,7 @@ def overnightFeatureDomains
 end
 
 addMode('overnight', 'Overnight semantic parsing', l(
-  header('core,freebase,overnight'),
+  header('core,corenlp,freebase,overnight'),
   'edu.stanford.nlp.sempre.Main',
   figOpts,
   o('JavaExecutor.convertNumberValues', false),

--- a/src/edu/stanford/nlp/sempre/corenlp/CoreNLPAnalyzer.java
+++ b/src/edu/stanford/nlp/sempre/corenlp/CoreNLPAnalyzer.java
@@ -34,6 +34,9 @@ public class CoreNLPAnalyzer extends LanguageAnalyzer {
 
     @Option(gloss = "Whether to use case-sensitive models")
     public boolean caseSensitive = false;
+
+    @Option(gloss = "Disable SUTime (which does not work with Java > 8")
+    public boolean disableSUTime = false;
   }
 
   public static Options opts = new Options();
@@ -61,6 +64,9 @@ public class CoreNLPAnalyzer extends LanguageAnalyzer {
     } else {
       props.put("pos.model", "edu/stanford/nlp/models/pos-tagger/english-caseless-left3words-distsim.tagger");
       props.put("ner.model", "edu/stanford/nlp/models/ner/english.all.3class.caseless.distsim.crf.ser.gz,edu/stanford/nlp/models/ner/english.conll.4class.caseless.distsim.crf.ser.gz");
+    }
+    if (opts.disableSUTime) {
+      props.put("ner.useSUTime", "0");
     }
     pipeline = new StanfordCoreNLP(props);
   }


### PR DESCRIPTION
Addresses #193.
- `./pull-dependencies corenlp-3.9.2` loads CoreNLP 3.9.2 (Oct 2018).
- `--disableSUTime` option turns off SUTime, which causes problems in Java > 8.