### PR TITLE
Updated run files to support the latest change in fig

### DIFF
--- a/interactive/run
+++ b/interactive/run
@@ -7,6 +7,7 @@
 
 $: << 'fig/lib'
 require 'execrunner'
+$optPrefix = '-'
 $path = 'interactive'
 $output = 'interactive/output'
 $modes = []

--- a/run
+++ b/run
@@ -7,6 +7,7 @@
 
 $: << 'fig/lib'
 require 'execrunner'
+$optPrefix = '-'
 
 $modes = []
 def addMode(name, description, func)


### PR DESCRIPTION
Addresses #213 

- The ruby run files specify command-line options like this: `o('hello', 'itsme')`
- The latest change in fig makes the specification above expand to `--hello itsme`. The options with the `--` prefix will expand to all possible matching option names. (See the actual behavior in [`OptionsParser.java`](https://github.com/percyliang/fig/blob/master/src/main/java/fig/basic/OptionsParser.java#L747) of fig). So this would set all values of any option whose name begins with `hello`, I think.
- This pull request makes it so that the specification expands to `-hello itsme`. This will select a single option that match the name `hello` the most (or throw an error if the option is ambiguous).